### PR TITLE
Improved runtime of color bleeding from O(n^2) to O(n)

### DIFF
--- a/src/main/java/com/gemserk/utils/imageprocessing/ColorBleedingEffect.java
+++ b/src/main/java/com/gemserk/utils/imageprocessing/ColorBleedingEffect.java
@@ -245,11 +245,9 @@ public class ColorBleedingEffect {
 				}
 			}
 
-			if (cant != 0) {
-				simpleColor.setRGB(r / cant, g / cant, b / cant, 0);
-				rgb[pixelIndex] = simpleColor.getRGB();
-				iterator.markAsInProgress();
-			}
+			simpleColor.setRGB(r / cant, g / cant, b / cant, 0);
+			rgb[pixelIndex] = simpleColor.getRGB();
+			iterator.markAsInProgress();
 		}
 
 		iterator.reset();


### PR DESCRIPTION
The speedup brings the runtime down from several minutes to a few seconds.

Instead of starting over in each iteration an efficient breadth-first search is done. Initially, only those fully transparent pixels are added to "pending" that have at least one neighbor which is not a fully transparent pixel. This is called the "border". This border is then subsequently extended/shifted in each iteration such that only relevant pixels are considered. In the old algorithm pixels that had only fully transparent neighbors were considered again and again in each iteration until the border finally reached those pixels.

Another optimization was done related to reading/writing the rgb array of BufferedImage.
